### PR TITLE
Allow custom 404 file

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,6 +22,13 @@ PATH_PREFIX = ""
 #INDEX_FILE = ""
 INDEX_FILE = "index.html"
 
+# 404 file to use for the bucket when a file is not found.
+# Incurs an additional read operation for 404 requests.
+# Set to "" to disable 404 behaviour.
+# Relative to the root of the bucket.
+NOTFOUND_FILE = ""
+#NOT_FOUND_FILE = "404.html"
+
 [[r2_buckets]]
 binding = "R2_BUCKET"
 bucket_name = "kot"         # Set this to your R2 bucket name. Required


### PR DESCRIPTION
Allows specifying a `NOTFOUND_FILE` variable to specify a custom file to serve for 404 responses.
This incurs an additional read operation for 404 requests (One to find out there's no file, another to fetch the 404 file) and they are not cached so whether you want that or not is up to user preference.

Perhaps we could cache the 404 file itself, rather than the request, which would drop the double operations when the 404 file is cached.

A couple headers are omitted when serving a 404 response, and the range is obviously ignored. That said, the files content type and etc should be intact so you can serve e.g. an image or text file as appropriate to your needs.

This feature is disabled by default to avoid the double read operations without the user opting in to the behaviour. If this were made default in the future, `404.html` would be a good standard filename to use.