### PR TITLE
fix for path without leading slash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export default {
         }
       }
 
-      if (path !== "/") {
+      if (path !== "/" && path.startsWith("/")) {
         path = path.substring(1);
       }
 


### PR DESCRIPTION
I'm using render inside my own route and encountered a strange problem.

It took a long time to find the cause of the problem.

I think it will be better if add a check