### PR TITLE
Make mobile nicer, round sizes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -325,5 +325,5 @@ function niceBytes(x: number) {
     n = n / 1000;
   }
 
-  return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + ' ' + units[l]);
+  return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + '' + units[l]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,6 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
     <meta charset="utf-8">
     <style type="text/css">
       td { padding-right: 16px; text-align: right; font-family: monospace }
-      td#wrapme {;}
       td:nth-of-type(1) { text-align: left; overflow-wrap: anywhere }
       td:nth-of-type(3) { white-space: nowrap }
       th { text-align: left; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
       htmlList.push(
         `      <tr>` +
         `<td><a href="${encodeURIComponent(name)}">${name}</a></td>` +
-        `<td class="wrapme">${file.uploaded.toISOString().split('.')[0].replace('T', ' ') + 'Z'}</td><td>${niceBytes(file.size)}</td></tr>`);
+        `<td class="wrapme">${file.uploaded.toISOString().split('.')[0].replace('T', ' ').slice(0, file.uploaded.toISOString().lastIndexOf(':')) + 'Z'}</td><td>${niceBytes(file.size)}</td></tr>`);
 
       if (lastModified == null || file.uploaded > lastModified) {
         lastModified = file.uploaded;

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
       td { padding-right: 16px; text-align: right; font-family: monospace }
       td#wrapme {;}
       td:nth-of-type(1) { text-align: left; overflow-wrap: anywhere}
+      td:nth-of-type(3) { white-space: nowrap }
       th { text-align: left; }
       @media (prefers-color-scheme: dark) {
         body {
@@ -325,5 +326,5 @@ function niceBytes(x: number) {
     n = n / 1000;
   }
 
-  return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + '' + units[l]);
+  return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + ' ' + units[l]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,10 +72,15 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
     for (let file of listing.objects) {
       let name = file.key.substring(path.length, file.key.length)
       if (name.startsWith(".") && env.HIDE_HIDDEN_FILES) continue;
+
+      let dateStr = file.uploaded.toISOString()
+      dateStr = dateStr.split('.')[0].replace('T', ' ')
+      dateStr = dateStr.slice(0, dateStr.lastIndexOf(':')) + 'Z'
+
       htmlList.push(
         `      <tr>` +
         `<td><a href="${encodeURIComponent(name)}">${name}</a></td>` +
-        `<td class="wrapme">${file.uploaded.toISOString().split('.')[0].replace('T', ' ').slice(0, file.uploaded.toISOString().lastIndexOf(':')) + 'Z'}</td><td>${niceBytes(file.size)}</td></tr>`);
+        `<td class="wrapme">${dateStr}</td><td>${niceBytes(file.size)}</td></tr>`);
 
       if (lastModified == null || file.uploaded > lastModified) {
         lastModified = file.uploaded;
@@ -94,7 +99,7 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
     <style type="text/css">
       td { padding-right: 16px; text-align: right; font-family: monospace }
       td#wrapme {;}
-      td:nth-of-type(1) { text-align: left; overflow-wrap: anywhere}
+      td:nth-of-type(1) { text-align: left; overflow-wrap: anywhere }
       td:nth-of-type(3) { white-space: nowrap }
       th { text-align: left; }
       @media (prefers-color-scheme: dark) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ interface Env {
   DIRECTORY_CACHE_CONTROL?: string
 }
 
+const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
 type ParsedRange = { offset: number, length: number } | { suffix: number };
 
 function rangeHasLength(object: ParsedRange): object is { offset: number, length: number } {
@@ -73,7 +75,7 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
       htmlList.push(
         `      <tr>` +
         `<td><a href="${encodeURIComponent(name)}">${name}</a></td>` +
-        `<td>${file.uploaded.toUTCString()}</td><td>${file.size}</td></tr>`);
+        `<td class="wrapme">${file.uploaded.toISOString().split('.')[0].replace('T', ' ') + 'Z'}</td><td>${niceBytes(file.size)}</td></tr>`);
 
       if (lastModified == null || file.uploaded > lastModified) {
         lastModified = file.uploaded;
@@ -87,10 +89,12 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
 <html>
   <head>
     <title>Index of ${path}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
     <style type="text/css">
       td { padding-right: 16px; text-align: right; font-family: monospace }
-      td:nth-of-type(1) { text-align: left; }
+      td#wrapme {;}
+      td:nth-of-type(1) { text-align: left; overflow-wrap: anywhere}
       th { text-align: left; }
       @media (prefers-color-scheme: dark) {
         body {
@@ -312,3 +316,14 @@ export default {
     return response;
   },
 };
+
+function niceBytes(x: number) {
+
+  let l = 0, n = parseInt(x.toString(), 10) || 0;
+
+  while (n >= 1000 && ++l) {
+    n = n / 1000;
+  }
+
+  return (n.toFixed(n < 10 && l > 0 ? 1 : 0) + ' ' + units[l]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ async function makeListingResponse(path: string, env: Env, request: Request): Pr
       htmlList.push(
         `      <tr>` +
         `<td><a href="${encodeURIComponent(name)}">${name}</a></td>` +
-        `<td class="wrapme">${dateStr}</td><td>${niceBytes(file.size)}</td></tr>`);
+        `<td>${dateStr}</td><td>${niceBytes(file.size)}</td></tr>`);
 
       if (lastModified == null || file.uploaded > lastModified) {
         lastModified = file.uploaded;


### PR DESCRIPTION
- Make time a modified ISO format
- Make sizes rounded to B, MB, GB, etc.
- Add back viewport change for mobile, make filenames (and only filenames) wrap anywhere to prevent horizontal scrolling.

For short filenames this is fine:

![image](https://github.com/kotx/render/assets/14004943/14c68de5-9c64-42b7-8a0d-edfdd6d5a1a5)

When long filenames are addedd, things start to wrap.

**However**, the time will wrap between the date and time and the size will not wrap at all:
![image](https://github.com/kotx/render/assets/14004943/897d4838-0056-41c4-9375-46aa0a5e5ef1)

Spaces don't make much difference:
![image](https://github.com/kotx/render/assets/14004943/d5fa9fd0-4a35-4dda-ae43-52feb86edfe1)

Nor do unicode names:
![image](https://github.com/kotx/render/assets/14004943/a604da4a-81c6-467c-9759-2b64c3f5a22b)
