### PR TITLE
Export env, upgrade actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
           node-version: '16'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import parseRange from "range-parser";
 
-interface Env {
+export interface Env {
   R2_BUCKET: R2Bucket,
   ALLOWED_ORIGINS?: string,
   CACHE_CONTROL?: string,


### PR DESCRIPTION
Exporting env lets me do funny things like 

```ts
import { Env as RenderEnv }  from "render2";
```

Upgrading Actions removes the scary deprecation warnings on Action runs.