### PR TITLE
Set `Allow` header for 405 requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,9 @@ ${htmlList.join("\n")}
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const allowedMethods = ["GET", "HEAD", "OPTIONS"];
-    if (allowedMethods.indexOf(request.method) === -1) return new Response("Method Not Allowed", { status: 405 });
+    if (allowedMethods.indexOf(request.method) === -1) {
+      return new Response("Method Not Allowed", { status: 405, headers: { "allow": allowedMethods.join(", ") } });
+    }
 
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: { "allow": allowedMethods.join(", ") } })


### PR DESCRIPTION
Allow header is required when returning a 405, https://developer.mozilla.org/en-US/docs/web/http/status/405