### PR TITLE
nit: don't parse url until it's needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,6 @@ export default {
 
     let triedIndex = false;
 
-    const url = new URL(request.url);
     let response: Response | undefined;
 
     const isCachingEnabled = env.CACHE_CONTROL !== "no-store"
@@ -162,6 +161,7 @@ export default {
 
     if (!response || !(response.ok || response.status == 304)) {
       console.warn("Cache miss");
+      const url = new URL(request.url);
       let path = (env.PATH_PREFIX || "") + decodeURIComponent(url.pathname);
 
       // directory logic


### PR DESCRIPTION
Bit of a nit, but the url isn't used unless there's a cache miss