### PR TITLE
Add logging env variable to enable console logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface Env {
   DIRECTORY_LISTING?: boolean
   HIDE_HIDDEN_FILES?: boolean
   DIRECTORY_CACHE_CONTROL?: string
+  LOGGING?: boolean
 }
 
 const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -33,7 +34,7 @@ function getRangeHeader(range: ParsedRange, fileSize: number): string {
     (range.offset + range.length - 1)}/${fileSize}`;
 }
 
-// some ideas for this were taken from / inspired by 
+// some ideas for this were taken from / inspired by
 // https://github.com/cloudflare/workerd/blob/main/samples/static-files-from-disk/static.js
 async function makeListingResponse(path: string, env: Env, request: Request): Promise<Response | null> {
   if (path === "/")
@@ -162,7 +163,9 @@ export default {
     let range: ParsedRange | undefined;
 
     if (!response || !(response.ok || response.status == 304)) {
-      console.warn("Cache miss");
+      if (env.LOGGING) {
+        console.warn("Cache miss");
+      }
       const url = new URL(request.url);
       let path = (env.PATH_PREFIX || "") + decodeURIComponent(url.pathname);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ export default {
 
     if (!response || !(response.ok || response.status == 304)) {
       if (env.LOGGING) {
-        console.warn("Cache miss");
+        console.warn("Cache MISS for", request.url);
       }
       const url = new URL(request.url);
       let path = (env.PATH_PREFIX || "") + decodeURIComponent(url.pathname);
@@ -321,6 +321,10 @@ export default {
 
       if (request.method === "GET" && !range && isCachingEnabled && !notFound)
         ctx.waitUntil(cache.put(request, response.clone()));
+    } else {
+      if (env.LOGGING) {
+        console.warn("Cache HIT for", request.url);
+      }
     }
 
     return response;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,7 +31,7 @@ NOTFOUND_FILE = ""
 #NOT_FOUND_FILE = "404.html"
 
 # Enable to show a directory listing fallback on paths ending in /
-# If INDEX_FILE is also provided, it will be used instead if the file exists. 
+# If INDEX_FILE is also provided, it will be used instead if the file exists.
 DIRECTORY_LISTING = false
 
 # Enable to hide files or directories beginning with . from directory listings.
@@ -39,6 +39,9 @@ HIDE_HIDDEN_FILES = false
 
 # Set a cache header here, e.g. "max-age=86400", if you want to cache directory listings.
 DIRECTORY_CACHE_CONTROL = "no-store"
+
+# Set debugging log enabled
+LOGGING = true
 
 [[r2_buckets]]
 binding = "R2_BUCKET"


### PR DESCRIPTION
When used as external package it may be annoying getting console.logs while development